### PR TITLE
restore database from s3 seed

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,9 +6,6 @@ ENV_DIR=$3
 
 echo "Compiling Narwhal"
 
-#curl -s https://cli-assets.heroku.com/heroku-linux-x64.tar.gz | tar xz || exit $?
-#export PATH=$PATH:./heroku/bin/ || exit $?
-
 APP_NAME=$(cat "${ENV_DIR}/HEROKU_APP_NAME")
 HEROKU_API_KEY=$(cat "${ENV_DIR}/HEROKU_API_KEY")
 
@@ -16,8 +13,6 @@ echo "APP_NAME ${APP_NAME}"
 
 if  [[ $APP_NAME ==  beluga-* ]] ;
 then
-#  heroku buildpacks:set heroku/ruby --app "${APP_NAME}"
-
 FE_APP_NAME="${APP_NAME/beluga/minke}"
 FE_URL="https://${FE_APP_NAME}.herokuapp.com"
 curl -n -X PATCH https://api.heroku.com/apps/$APP_NAME/config-vars \
@@ -62,10 +57,43 @@ curl -n -X PUT https://api.heroku.com/apps/$APP_NAME/buildpack-installations \
   -H "Accept: application/vnd.heroku+json; version=3" \
   -H "Authorization: Bearer $HEROKU_API_KEY"
 
+# Taken from https://github.com/heroku/heroku-buildpack-awscli/blob/master/bin/compile
+AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+INSTALL_DIR="/app/.awscli"
+TMP_DIR=$(mktemp -d)
+
+echo "-----> Downloading AWS CLI"
+curl --silent --show-error --fail -o "${TMP_DIR}/awscliv2.zip" "${AWS_CLI_URL}"
+unzip -qq -d "${TMP_DIR}" "${TMP_DIR}/awscliv2.zip"
+
+echo "-----> Installing AWS CLI"
+mkdir -p "${BUILD_DIR}/.awscli"
+
+if [[ "${BUILD_DIR}" != /app ]]; then
+  mkdir -p /app
+  ln -nsf "${BUILD_DIR}/.awscli" "${INSTALL_DIR}"
+fi
+
+"${TMP_DIR}/aws/install" --install-dir "${INSTALL_DIR}/aws-cli" --bin-dir "${INSTALL_DIR}/bin"
+/app/.awscli/bin/aws --version
+
+rm -rf "${TMP_DIR}"
+
+echo "-----> Successfully installed AWS CLI"
+
+# Install heroku cli (needed for db restore)
 curl -s https://cli-assets.heroku.com/heroku-linux-x64.tar.gz | tar xz || exit $?
 export PATH=$PATH:./heroku/bin/ || exit $?
 
-HEROKU_API_KEY=$(cat "${ENV_DIR}/HEROKU_API_KEY") heroku pg:copy beluga-dev::DATABASE_URL DATABASE_URL --app "${APP_NAME}" --confirm "${APP_NAME}"
+# Create signed url
+signed_url="$(
+export AWS_ACCESS_KEY_ID=$(cat "${ENV_DIR}/AWS_NARWHAL_ACCESS_KEY_ID")
+export AWS_SECRET_ACCESS_KEY=$(cat "${ENV_DIR}/AWS_NARWHAL_SECRET_ACCESS_KEY")
+/app/.awscli/bin/aws s3 presign s3://opencomp-seed-data/seed.dump --region=us-east-2
+)"
+
+# Restore database from seed
+HEROKU_API_KEY=$(cat "${ENV_DIR}/HEROKU_API_KEY") heroku pg:backups:restore "${signed_url}" DATABASE_URL --app "${APP_NAME}" --confirm "${APP_NAME}"
 
 elif  [[ $APP_NAME == minke-* ]] ;
 then
@@ -82,7 +110,6 @@ curl -n -X PATCH https://api.heroku.com/apps/$APP_NAME/config-vars \
   -H "Accept: application/vnd.heroku+json; version=3" \
   -H "Authorization: Bearer $HEROKU_API_KEY"
 
-#  heroku buildpacks:set heroku/nodejs --app "${APP_NAME}"
 curl -n -X PUT https://api.heroku.com/apps/$APP_NAME/buildpack-installations \
   -d '{
   "updates": [
@@ -104,3 +131,4 @@ else
 echo "Invalid app name"
 fi
 
+echo "Finished"


### PR DESCRIPTION
Update the buildpack to restore db from the seed in s3 rather than from dev.

Required installing the aws cli to generate the presigned url.

Was testing with this branch: https://github.com/OpenCompHQ/orca/compare/dev...john-test/1.22.0