### PR TITLE
Add vite vars

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -104,7 +104,9 @@ WS_URL="${BE_URL}/cable"
 curl -n -X PATCH https://api.heroku.com/apps/$APP_NAME/config-vars \
   -d '{
   "REACT_APP_API_URL": "'$BE_URL'",
-  "REACT_APP_WS_URL": "'$WS_URL'"
+  "REACT_APP_WS_URL": "'$WS_URL'",
+  "VITE_API_URL": "'$BE_URL'",
+  "VITE_WS_URL": "'$WS_URL'"
 }' \
   -H "Content-Type: application/json" \
   -H "Accept: application/vnd.heroku+json; version=3" \


### PR DESCRIPTION
There is a "sync-heroku-pipeline-vars.yaml" workflow that runs whenever a PR is opened. It will overwrite the minke/beluga pipeline config vars in heroku, which means depending on which branch a PR is opened from, building a review app may or may not work.

This change simply provides both sets of config vars with the same values, so review apps can be created against either main or dev.