### PR TITLE
Pin aws cli to 2.13.33 to avoid breaking change

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -58,7 +58,9 @@ curl -n -X PUT https://api.heroku.com/apps/$APP_NAME/buildpack-installations \
   -H "Authorization: Bearer $HEROKU_API_KEY"
 
 # Taken from https://github.com/heroku/heroku-buildpack-awscli/blob/master/bin/compile
-AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+# Pin to version 2.13.33 https://github.com/aws/aws-cli/issues/8320
+# AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.13.33.zip"
 INSTALL_DIR="/app/.awscli"
 TMP_DIR=$(mktemp -d)
 


### PR DESCRIPTION
Successfully tested and verified AWS cli gets installed properly

https://dashboard.heroku.com/apps/beluga-pr-8155/activity/builds/3ca917c2-8f63-4726-8444-472b8a1cd598