### PR TITLE
Remove REACT_APP vars

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -105,8 +105,6 @@ BE_URL="https://${BE_APP_NAME}.herokuapp.com"
 WS_URL="${BE_URL}/cable"
 curl -n -X PATCH https://api.heroku.com/apps/$APP_NAME/config-vars \
   -d '{
-  "REACT_APP_API_URL": "'$BE_URL'",
-  "REACT_APP_WS_URL": "'$WS_URL'",
   "VITE_API_URL": "'$BE_URL'",
   "VITE_WS_URL": "'$WS_URL'"
 }' \


### PR DESCRIPTION
Now that vite is in production and used across all envs, we can get rid of the old REACT_APP vars.