### PR TITLE
Unpin aws cli version now that installation is fixed in 2.13.35

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -58,9 +58,7 @@ curl -n -X PUT https://api.heroku.com/apps/$APP_NAME/buildpack-installations \
   -H "Authorization: Bearer $HEROKU_API_KEY"
 
 # Taken from https://github.com/heroku/heroku-buildpack-awscli/blob/master/bin/compile
-# Pin to version 2.13.33 https://github.com/aws/aws-cli/issues/8320
-# AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
-AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.13.33.zip"
+AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
 INSTALL_DIR="/app/.awscli"
 TMP_DIR=$(mktemp -d)
 


### PR DESCRIPTION
The issue has been resolved https://github.com/aws/aws-cli/issues/8320#issuecomment-1809264792