### PR TITLE
Update Postgres plan

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ curl -n -X PATCH https://api.heroku.com/apps/$APP_NAME/config-vars \
 
 curl -n -X POST https://api.heroku.com/apps/$APP_NAME/addons \
   -d '{
-  "plan": "heroku-postgresql:basic"
+  "plan": "heroku-postgresql:essential-1"
 }' \
   -H "Content-Type: application/json" \
   -H "Accept: application/vnd.heroku+json; version=3" \


### PR DESCRIPTION
[`basic` is EOL as of 2024-05-29](https://devcenter.heroku.com/articles/heroku-postgres-plans#mini-and-basic-deprecation-details)
